### PR TITLE
Update Python version classifiers in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,11 @@ description = "A polars extension"
 requires-python = ">=3.10"
 classifiers = [
   "Programming Language :: Rust",
+  "Programming Language :: Python",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]


### PR DESCRIPTION
- Add support for Python 3.10, 3.11, 3.12, and 3.13 in project metadata
- Expand Python version compatibility for the project