### PR TITLE
Update GitHub Actions publish workflow

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -2,10 +2,8 @@ name: Publish
 
 on:
   push:
-    branches:
-      - main
     tags:
-      - "*"
+      - "[0-9]+.[0-9]+.[0-9]+"
   workflow_dispatch:
 
 permissions:
@@ -125,7 +123,7 @@ jobs:
         with:
           subject-path: "wheels-*/*"
       - name: Publish to PyPI
-        if: ${{ startsWith(github.ref, 'refs/tags/') }}
+        if: ${{ matches(github.ref, '^refs/tags/[0-9]+\.[0-9]+\.[0-9]+$') }}
         uses: PyO3/maturin-action@v1
         env:
           MATURIN_PYPI_TOKEN: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
- Modify trigger conditions to only publish on semantic version tags
- Update PyPI publish step to use regex matching for version tags
- Simplify branch and tag triggering configuration