### PR TITLE
Rename 'center' to 'offset' in linear transform fit implementation

### DIFF
--- a/crates/core/src/optimize.rs
+++ b/crates/core/src/optimize.rs
@@ -5,11 +5,11 @@ pub fn linear_fit(
     y: &Float64Chunked,
 ) -> PolarsResult<(Option<f64>, Option<f64>)> {
     if x.len() != y.len() {
-        polars_bail!(ShapeMismatch: "x and y must have the same length, got x: {}, y: {}", x.len(), y.len())
+        polars_bail!(ShapeMismatch: "x and y must have the same length, got x: {}, y: {}", x.len(), y.len());
     }
 
     if x.is_empty() {
-        polars_bail!(ComputeError: "Cannot perform linear regression on empty arrays")
+        polars_bail!(ComputeError: "Cannot perform linear regression on empty arrays");
     }
 
     let valid_mask = x.is_not_null() & y.is_not_null();
@@ -34,7 +34,7 @@ pub fn linear_fit(
     });
 
     if denominator.abs() < f64::EPSILON {
-        polars_bail!(ComputeError: "Denominator is zero, cannot compute slope")
+        polars_bail!(ComputeError: "Denominator is zero, cannot compute slope");
     }
 
     let slope = numerator / denominator;

--- a/crates/python/src/optimize.rs
+++ b/crates/python/src/optimize.rs
@@ -13,7 +13,7 @@ fn linear_fit_output(_: &[Field]) -> PolarsResult<Field> {
 #[polars_expr(output_type_func = linear_fit_output)]
 fn linear_fit(inputs: &[Series]) -> PolarsResult<Series> {
     if inputs.len() != 2 {
-        polars_bail!(ComputeError: "linear_fit expects 2 input series, got {}", inputs.len())
+        polars_bail!(ComputeError: "linear_fit expects 2 input series, got {}", inputs.len());
     }
 
     let x = inputs[0].f64()?;
@@ -33,7 +33,7 @@ fn linear_fit(inputs: &[Series]) -> PolarsResult<Series> {
 fn linear_transform_fit_output(_: &[Field]) -> PolarsResult<Field> {
     let fields = vec![
         Field::new("scale".into(), DataType::Float64),
-        Field::new("center".into(), DataType::Float64),
+        Field::new("offset".into(), DataType::Float64),
     ];
     Ok(Field::new(
         "linear_transform_fit".into(),
@@ -44,28 +44,28 @@ fn linear_transform_fit_output(_: &[Field]) -> PolarsResult<Field> {
 #[polars_expr(output_type_func = linear_transform_fit_output)]
 fn linear_transform_fit(inputs: &[Series]) -> PolarsResult<Series> {
     if inputs.len() != 2 {
-        polars_bail!(ComputeError: "linear_transform_fit expects 2 input series, got {}", inputs.len())
+        polars_bail!(ComputeError: "linear_transform_fit expects 2 input series, got {}", inputs.len());
     }
 
     let x = inputs[0].f64()?;
     let y = inputs[1].f64()?;
 
     let scale;
-    let center;
+    let offset;
 
     if let (Some(slope), Some(intercept)) = optimize::linear_fit(x, y)? {
         scale = Some(1.0 / slope);
-        center = Some(-intercept / slope);
+        offset = Some(-intercept / slope);
     } else {
         scale = None;
-        center = None;
+        offset = None;
     };
 
     let scale = Series::new("scale".into(), &[scale]);
-    let center = Series::new("center".into(), &[center]);
+    let offset = Series::new("offset".into(), &[offset]);
 
     Ok(
-        StructChunked::from_series("linear_transform_fit".into(), 1, [scale, center].iter())?
+        StructChunked::from_series("linear_transform_fit".into(), 1, [scale, offset].iter())?
             .into_series(),
     )
 }

--- a/src/ivory/optimize.py
+++ b/src/ivory/optimize.py
@@ -38,7 +38,7 @@ def linear_transform_fit(x: IntoExprColumn, y: IntoExprColumn) -> Expr:
     """Perform linear regression on the input series.
 
     This function fits a linear model to the input series and
-    returns the center and scale.
+    returns the scale and offset.
 
     Args:
         x (IntoExprColumn): The independent variable.
@@ -46,7 +46,7 @@ def linear_transform_fit(x: IntoExprColumn, y: IntoExprColumn) -> Expr:
 
     Returns:
         Expr: A polars expression that evaluates to a struct
-        with the center and scale.
+        with the scale and offset.
     """
     return register_plugin_function(
         args=[x, y],

--- a/tests/optimize/test_linear_transform_fit.py
+++ b/tests/optimize/test_linear_transform_fit.py
@@ -35,7 +35,7 @@ def test_linear_transform_fit(df: DataFrame, params):
 
     x = df["scale"].to_list()[0]
     np.testing.assert_allclose(x, params[0], rtol=1e-2)
-    x = df["center"].to_list()[0]
+    x = df["offset"].to_list()[0]
     np.testing.assert_allclose(x, params[1], rtol=1e-2)
 
 
@@ -45,7 +45,7 @@ def test_linear_transform_fit_one():
     df = DataFrame({"x": [1.0], "y": [2.0]})
     df = df.select(linear_transform_fit("x", "y").struct.unnest())
     assert df["scale"].is_null().all()
-    assert df["center"].is_null().all()
+    assert df["offset"].is_null().all()
 
 
 def test_linear_transform_fit_agg(inputs):
@@ -65,10 +65,10 @@ def test_linear_transform_fit_agg(inputs):
 
     x = df["scale"].to_list()[0]
     np.testing.assert_allclose(x, p1[0], rtol=1e-2)
-    x = df["center"].to_list()[0]
+    x = df["offset"].to_list()[0]
     np.testing.assert_allclose(x, p1[1], rtol=1e-2)
 
     x = df["scale"].to_list()[1]
     np.testing.assert_allclose(x, p2[0], rtol=1e-2)
-    x = df["center"].to_list()[1]
+    x = df["offset"].to_list()[1]
     np.testing.assert_allclose(x, p2[1], rtol=1e-2)


### PR DESCRIPTION
- Update Rust and Python code to use 'offset' instead of 'center'
- Modify function signatures, docstrings, and test cases
- Ensure consistent terminology across Rust and Python implementations