### PR TITLE
Update PyPI publish workflow condition

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,7 +24,7 @@ jobs:
         run: ruff check
 
   rust-test:
-    name: Rust Tests
+    name: Rust
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -36,8 +36,6 @@ jobs:
             ~/.cargo/git
             target
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-      - name: Install cargo-tarpaulin
-        run: cargo install cargo-tarpaulin
       - name: Run tests
         run: cargo test -p ivory-core
 
@@ -59,7 +57,7 @@ jobs:
           uv sync
       - name: Build the project
         run: uv run maturin develop
-      - name: Run test with coverage
+      - name: Run tests
         run: uv run pytest -v --cov=ivory --cov-report=lcov:lcov.info --junitxml=junit.xml
       - name: Upload Python coverage to Codecov
         uses: codecov/codecov-action@v4

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -122,7 +122,7 @@ jobs:
         with:
           subject-path: "wheels-*/*"
       - name: Publish to PyPI
-        if: ${{ matches(github.ref, '^refs/tags/[0-9]+\.[0-9]+\.[0-9]+$') }}
+        if: ${{ startsWith(github.ref, 'refs/tags/') }}
         uses: PyO3/maturin-action@v1
         env:
           MATURIN_PYPI_TOKEN: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
Modify GitHub Actions publish workflow to trigger on any tag instead of strictly semantic versioning tags